### PR TITLE
Validate tokens for message queue

### DIFF
--- a/src/EventListener/SendNotificationMessageListener.php
+++ b/src/EventListener/SendNotificationMessageListener.php
@@ -35,8 +35,10 @@ class SendNotificationMessageListener
 
             if (Validator::isBinaryUuid($token)) {
                 $fileModel = FilesModel::findByUuid($token);
-                $arrTokens[$key] = $fileModel->path;
-                continue;
+                if ($fileModel) {
+                    $arrTokens[$key] = $fileModel->path;
+                    continue;
+                }
             }
 
             if (false === json_encode($token)) {

--- a/src/EventListener/SendNotificationMessageListener.php
+++ b/src/EventListener/SendNotificationMessageListener.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Terminal42\NewsNewsletterBundle\EventListener;
+
+use Contao\CoreBundle\ServiceAnnotation\Hook;
+use Contao\FilesModel;
+use Contao\Validator;
+use NotificationCenter\Model\Gateway;
+use NotificationCenter\Model\Message;
+
+/**
+ * @Hook("sendNotificationMessage")
+ */
+class SendNotificationMessageListener
+{
+    /**
+     * @param Message $objMessage
+     * @param array $arrTokens
+     * @param string $language
+     * @param Gateway $objGatewayModel
+     * @return bool
+     */
+    public function __invoke($objMessage, &$arrTokens, $language, $objGatewayModel): bool
+    {
+        if (($objMessage->getRelated('pid')->type !== 'news_newsletter_default')
+            || 'queue' !== $objMessage->gateway_type
+            || (false !== json_encode($arrTokens))) {
+            return true;
+        }
+
+        foreach ($arrTokens as $key => $token) {
+            if (false !== json_encode($token)) {
+                continue;
+            }
+
+            if (Validator::isBinaryUuid($token)) {
+                $fileModel = FilesModel::findByUuid($token);
+                $arrTokens[$key] = $fileModel->path;
+                continue;
+            }
+
+            if (false === json_encode($token)) {
+                unset($arrTokens[$key]);
+            }
+        }
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
This PR fix issues with notification queue. 
If the news article containers invalid characters for json encode, tokens are not stored in the queue. This PR fixes this issue with replacing uuids with file paths and removing other invalid tokens, if exist. 
This is not really an issue of this extension, it's an issue of notification center (https://github.com/terminal42/contao-notification_center/issues/248).

